### PR TITLE
add 3 new in-app tutorials

### DIFF
--- a/in-app-tutorials/getting-started/shared-tutorials/analyze-test-reports.md
+++ b/in-app-tutorials/getting-started/shared-tutorials/analyze-test-reports.md
@@ -1,6 +1,6 @@
 ## Analyze test reports
 
-1. Go to Project > Settings > Katalon Platform. Make sure Katalon Platform integration and automatically upload reports options are enabled.
+1. Go to **Project** > **Settings** > **Katalon Platform**. Make sure you have enabled Katalon Platform integration and automatically upload all test reports to Katalon Platform.
 
     <img src="https://github.com/katalon-studio/docs-images/raw/master/katalon-studio/in-app-tutorials/shared-images/ks-upload-reports-enabled.png" width=350>
 

--- a/in-app-tutorials/getting-started/shared-tutorials/analyze-test-reports.md
+++ b/in-app-tutorials/getting-started/shared-tutorials/analyze-test-reports.md
@@ -1,0 +1,15 @@
+## Analyze test reports
+
+In the **Tests Explorer** sidebar, click **TestOps** and choose **Test Runs**.
+
+<img src="https://github.com/katalon-studio/docs-images/raw/master/katalon-studio/in-app-tutorials/shared-images/ks-open-test-runs-list.png" width=50%>
+
+You can view a summary list of the test runs. 
+
+<img src="https://github.com/katalon-studio/docs-images/raw/master/katalon-studio/in-app-tutorials/shared-images/ks-view-test-runs.png" width=100%>
+
+You can also view advanced reports of the test runs in Katalon Platform.
+* To view the advanced report of a test case, click on the test run ID. 
+* To view advanced reports of all test runs, click on **View all test runs**. 
+
+> [Click here for a detailed tutorial](https://docs.katalon.com/docs/analyze/reports/view-test-reports/view-test-reports-in-katalon-testops/test-runs-reports-overview-in-katalon-testops)

--- a/in-app-tutorials/getting-started/shared-tutorials/analyze-test-reports.md
+++ b/in-app-tutorials/getting-started/shared-tutorials/analyze-test-reports.md
@@ -1,15 +1,16 @@
 ## Analyze test reports
 
-In the **Tests Explorer** sidebar, click **TestOps** and choose **Test Runs**.
+1. Go to Project > Settings > Katalon Platform. Make sure Katalon Platform integration and automatically upload reports options are enabled.
 
-<img src="https://github.com/katalon-studio/docs-images/raw/master/katalon-studio/in-app-tutorials/shared-images/ks-open-test-runs-list.png" width=50%>
+    <img src="https://github.com/katalon-studio/docs-images/raw/master/katalon-studio/in-app-tutorials/shared-images/ks-upload-reports-enabled.png" width=350>
 
-You can view a summary list of the test runs. 
+   After execution, your test suite reports are automatically uploaded to Platform.
 
-<img src="https://github.com/katalon-studio/docs-images/raw/master/katalon-studio/in-app-tutorials/shared-images/ks-view-test-runs.png" width=100%>
+2. Go to your Project Dashboard on [Katalon Platform](https://testops.katalon.io). 
 
-You can also view advanced reports of the test runs in Katalon Platform.
-* To view the advanced report of a test case, click on the test run ID. 
-* To view advanced reports of all test runs, click on **View all test runs**. 
+    <img src="https://github.com/katalon-studio/docs-images/raw/master/katalon-studio/in-app-tutorials/shared-images/kt-dashboard.png" width=350>
+    
+    Here you can access the advanced reports and analytics of your test execution.
 
-> [Click here for a detailed tutorial](https://docs.katalon.com/docs/analyze/reports/view-test-reports/view-test-reports-in-katalon-testops/test-runs-reports-overview-in-katalon-testops)
+
+> [Click here for more information](https://docs.katalon.com/docs/analyze/reports/view-test-reports/view-test-reports-in-katalon-testops/view-testops-dashboard/testops-dashboard-overview)

--- a/in-app-tutorials/getting-started/shared-tutorials/analyze-test-reports.md
+++ b/in-app-tutorials/getting-started/shared-tutorials/analyze-test-reports.md
@@ -8,7 +8,7 @@
 
 2. Go to your Project Dashboard on [Katalon Platform](https://testops.katalon.io). 
 
-    <img src="https://github.com/katalon-studio/docs-images/raw/master/katalon-studio/in-app-tutorials/shared-images/kt-dashboard.png" width=350>
+    <img src="https://github.com/katalon-studio/docs-images/raw/master/katalon-studio/in-app-tutorials/shared-images/kt-dashboard-1.png" width=350>
     
     Here you can access the advanced reports and analytics of your test execution.
 

--- a/in-app-tutorials/getting-started/shared-tutorials/execute-with-kre.md
+++ b/in-app-tutorials/getting-started/shared-tutorials/execute-with-kre.md
@@ -1,11 +1,39 @@
 ## Execute tests with Katalon Runtime Engine
 
-1. Open **Command Builder** from the main toolbar.
-   <img src="https://github.com/katalon-studio/docs-images/raw/master/katalon-studio/in-app-tutorials/shared-images/open-command-builder.png" width=100%>
+1. Download Katalon Runtime Engine from Katalon website: [Katalon](https://katalon.com/download).
 
-1. In the displayed **Generate Command for Console Mode** dialog, configure your execution with the provided options:
+2. Open the Command Prompt on your machine:
+   <details>
+      <summary>For macOS</summary>
+  
+     1. Extract the zip file.
+     2. In the extracted folder, right-click on **Katalon Studio Engine** and select "Show Package Contents".
+     3. Go to Contents > MacOS. Right-click on MacOS folder and select "New Terminal at Folder".
 
-   <img src="https://github.com/katalon-studio/docs-images/raw/master/katalon-studio/in-app-tutorials/shared-images/generate-command-console-mode.png" width=100%>
+   </details>
+
+   <details>
+      <summary>For Windows</summary>
+
+      1. Extract the zip file.
+      2. In the extracted folder, type “cmd” in the folder path and enter to launch the Command Prompt.
+
+   </details>
+
+   <details>
+      <summary>For Linux</summary>
+
+      1. Extract the zip file.
+      2. Right-click on the extracted folder and select "Open in Terminal". 
+
+   </details>
+
+3. Open **Command Builder** from the main toolbar.
+   <img src="https://github.com/katalon-studio/docs-images/raw/master/katalon-studio/in-app-tutorials/shared-images/open-command-builder.png" width=250>
+
+4. In the displayed **Generate Command for Console Mode** dialog, configure your execution with the provided options:
+
+   <img src="https://github.com/katalon-studio/docs-images/raw/master/katalon-studio/in-app-tutorials/shared-images/generate-command-console-mode.png" width=300>
 
 * **Test Suite:** select the Test Suite / Test Suite Collection you want to execute.
 
@@ -14,12 +42,14 @@
 
 * **Authentication:** the Katalon API key is auto-filled.
 
-1. Click **Generate Command** after completing the configuration.
+5. Click **Generate Command** after completing the configuration.
 
-2. Click **Copy to Clipboard** and paste the command to your Command Prompt/Terminal for execution.
+6. Click **Copy to Clipboard** and paste the command to your Command Prompt/Terminal for execution.
 
-   <img src="https://github.com/katalon-studio/docs-images/raw/master/katalon-studio/in-app-tutorials/shared-images/generated-command.png" width=100%>
-   
-   > [Click here for a detailed tutorial](https://docs.katalon.com/docs/execute/katalon-runtime-engine/command-line-syntax-in-katalon-runtime-engine#command-builder-in-katalon-studio)
+   <img src="https://github.com/katalon-studio/docs-images/raw/master/katalon-studio/in-app-tutorials/shared-images/generated-command.png" width=280>
+
+7. [Click here](https://docs.katalon.com/docs/general-information/supported-integration/supported-integrations-in-katalon-platform#cicd-integration) to explore the supported CI/CD integrations.
+
+   > [Click here for a detailed KRE execution tutorial](https://docs.katalon.com/docs/execute/katalon-runtime-engine/command-line-syntax-in-katalon-runtime-engine#command-builder-in-katalon-studio)
 
 

--- a/in-app-tutorials/getting-started/shared-tutorials/execute-with-kre.md
+++ b/in-app-tutorials/getting-started/shared-tutorials/execute-with-kre.md
@@ -48,8 +48,12 @@
 
    <img src="https://github.com/katalon-studio/docs-images/raw/master/katalon-studio/in-app-tutorials/shared-images/generated-command.png" width=280>
 
-7. [Click here](https://docs.katalon.com/docs/general-information/supported-integration/supported-integrations-in-katalon-platform#cicd-integration) to explore the supported CI/CD integrations.
+> [Click here for a detailed KRE execution tutorial](https://docs.katalon.com/docs/execute/katalon-runtime-engine/get-started-with-katalon-runtime-engine)
 
-   > [Click here for a detailed KRE execution tutorial](https://docs.katalon.com/docs/execute/katalon-runtime-engine/command-line-syntax-in-katalon-runtime-engine#command-builder-in-katalon-studio)
+ Katalon Runtime Engine supports running tests in several CI environments. Depending on your preference, you can integrate with GitLab, Github Action, or Azure DevOps. 
+ 
+ [Click here](https://docs.katalon.com/docs/general-information/supported-integration/supported-integrations-in-katalon-platform#cicd-integration) to explore other supported CI/CD integrations.
+
+   
 
 

--- a/in-app-tutorials/getting-started/shared-tutorials/execute-with-kre.md
+++ b/in-app-tutorials/getting-started/shared-tutorials/execute-with-kre.md
@@ -1,0 +1,25 @@
+## Execute tests with Katalon Runtime Engine
+
+1. Open **Command Builder** from the main toolbar.
+   <img src="https://github.com/katalon-studio/docs-images/raw/master/katalon-studio/in-app-tutorials/shared-images/open-command-builder.png" width=100%>
+
+1. In the displayed **Generate Command for Console Mode** dialog, configure your execution with the provided options:
+
+   <img src="https://github.com/katalon-studio/docs-images/raw/master/katalon-studio/in-app-tutorials/shared-images/generate-command-console-mode.png" width=100%>
+
+* **Test Suite:** select the Test Suite / Test Suite Collection you want to execute.
+
+* **Executive Platform:**
+   * **Run with:** Click on Edit and select an environment to run your tests with.
+
+* **Authentication:** the Katalon API key is auto-filled.
+
+1. Click **Generate Command** after completing the configuration.
+
+2. Click **Copy to Clipboard** and paste the command to your Command Prompt/Terminal for execution.
+
+   <img src="https://github.com/katalon-studio/docs-images/raw/master/katalon-studio/in-app-tutorials/shared-images/generated-command.png" width=100%>
+   
+   > [Click here for a detailed tutorial](https://docs.katalon.com/docs/execute/katalon-runtime-engine/command-line-syntax-in-katalon-runtime-engine#command-builder-in-katalon-studio)
+
+

--- a/in-app-tutorials/getting-started/shared-tutorials/execute-with-kre.md
+++ b/in-app-tutorials/getting-started/shared-tutorials/execute-with-kre.md
@@ -53,7 +53,3 @@
  Katalon Runtime Engine supports running tests in several CI environments. Depending on your preference, you can integrate with GitLab, Github Action, or Azure DevOps. 
  
  [Click here](https://docs.katalon.com/docs/general-information/supported-integration/supported-integrations-in-katalon-platform#cicd-integration) to explore other supported CI/CD integrations.
-
-   
-
-

--- a/in-app-tutorials/getting-started/shared-tutorials/run-test-with-testcloud.md
+++ b/in-app-tutorials/getting-started/shared-tutorials/run-test-with-testcloud.md
@@ -1,18 +1,22 @@
 ## Run tests with TestCloud
 
-1. Open a Test Suite.
+1. Go to **Project** > **Settings** > **Katalon Platform**. Make sure Katalon Platform and TestCloud integrations are enabled.
 
-2. Click on the dropdown icon of the Run button and choose to run with TestCloud.
+   <img src="https://github.com/katalon-studio/docs-images/raw/master/katalon-studio/in-app-tutorials/shared-images/ks-testcloud-enabled.png" width=350>
 
-   <img src="https://github.com/katalon-studio/docs-images/raw/master/katalon-studio/in-app-tutorials/shared-images/select-testcloud.png" width=40%>
+2. Open a Test Suite.
 
-3. In the **TestCloud Configuration** dialog, select between Desktop or Mobile environment.
+3. Click on the dropdown icon of the Run button and choose to run with TestCloud.
+
+   <img src="https://github.com/katalon-studio/docs-images/raw/master/katalon-studio/in-app-tutorials/shared-images/select-testcloud.png" width=128>
+
+4. In the **TestCloud Configuration** dialog, select between Desktop or Mobile environment.
    * Desktop: Select the desired OS, browser, and browser version.
    * Mobile: Select the desired OS, OS version, and devices. The default browser is Chrome for Android, and Safari for iOS.
    
-   <img src="https://github.com/katalon-studio/docs-images/raw/master/katalon-studio/in-app-tutorials/shared-images/testcloud-config.png" width=100%>
+   <img src="https://github.com/katalon-studio/docs-images/raw/master/katalon-studio/in-app-tutorials/shared-images/testcloud-config.png" width=350>
 
-4. When you finish, click **Run**.
+5. When you finish, click **Run**.
 
    > [Click here for detailed tutorial](https://docs.katalon.com/docs/execute/cloud-based-test-execution/test-execution-with-testcloud/use-testcloud-in-katalon-studio#run-test-suites-with-testcloud)
 

--- a/in-app-tutorials/getting-started/shared-tutorials/run-test-with-testcloud.md
+++ b/in-app-tutorials/getting-started/shared-tutorials/run-test-with-testcloud.md
@@ -1,0 +1,19 @@
+## Run tests with TestCloud
+
+1. Open a Test Suite.
+
+2. Click on the dropdown icon of the Run button and choose to run with TestCloud.
+
+   <img src="https://github.com/katalon-studio/docs-images/raw/master/katalon-studio/in-app-tutorials/shared-images/select-testcloud.png" width=40%>
+
+3. In the **TestCloud Configuration** dialog, select between Desktop or Mobile environment.
+   * Desktop: Select the desired OS, browser, and browser version.
+   * Mobile: Select the desired OS, OS version, and devices. The default browser is Chrome for Android, and Safari for iOS.
+   
+   <img src="https://github.com/katalon-studio/docs-images/raw/master/katalon-studio/in-app-tutorials/shared-images/testcloud-config.png" width=100%>
+
+4. When you finish, click **Run**.
+
+   > [Click here for detailed tutorial](https://docs.katalon.com/docs/execute/cloud-based-test-execution/test-execution-with-testcloud/use-testcloud-in-katalon-studio#run-test-suites-with-testcloud)
+
+


### PR DESCRIPTION
Added three shared tutorials for KRE, R&A, and TestCloud. See ticket TDAP-1489.