### PR TITLE
Fix image tag in marketing content for Studio 11.3.0

### DIFF
--- a/katalon-start-page/marketing-content.md
+++ b/katalon-start-page/marketing-content.md
@@ -1,6 +1,6 @@
 ### [Studio 11.3.0 is here 🎉](https://docs.katalon.com/katalon-studio/release-notes/katalon-studio-release-notes-version-11.x)
 
-[<img width="672" height="688" alt="image" src="https://github.com/user-attachments/assets/b44eb198-3525-4843-b362-5c6fb7806fad" />](https://docs.katalon.com/katalon-studio/release-notes/katalon-studio-release-notes-version-11.x)
+[<img src="https://github.com/user-attachments/assets/b44eb198-3525-4843-b362-5c6fb7806fad" />](https://docs.katalon.com/katalon-studio/release-notes/katalon-studio-release-notes-version-11.x)
 
 **🧩 See your whole test flow**: Group AI, recorder, or manual steps under a named intention like "Login" — traceable from intent to automation. [Learn more →](https://docs.katalon.com/katalon-studio/release-notes/katalon-studio-release-notes-version-11.x#intention-groups-for-generated-and-manual-test-steps)
 


### PR DESCRIPTION
Updated image tag for Studio 11.3.0 announcement.

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**📚 Documentation**
* Updated marketing image tag to remove fixed attributes in markdown


<sup>[More info](https://app.aikido.dev/featurebranch/scan/140333812?groupId=17424)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->